### PR TITLE
Print out more of the traceback when throwing pyMOOSException

### DIFF
--- a/src/pyMOOS.cpp
+++ b/src/pyMOOS.cpp
@@ -100,8 +100,9 @@ public:
             bResult = py::bool_(result);
         } catch (const py::error_already_set& e) {
             PyGILState_Release(gstate);
-            throw pyMOOSException(
-                  "OnConnect:: caught an exception thrown in python callback");
+            std::string err_msg = "OnConnect:: caught an exception thrown in python callback:\n";
+            err_msg.append(e.what());
+            throw pyMOOSException(err_msg.c_str());
         }
 
         PyGILState_Release(gstate);
@@ -133,8 +134,9 @@ public:
             }
         } catch (const py::error_already_set& e) {
             PyGILState_Release(gstate);
-            throw pyMOOSException(
-                      "OnMail:: caught an exception thrown in python callback");
+            std::string err_msg = "OnMail:: caught an exception thrown in python callback:\n";
+            err_msg.append(e.what());
+            throw pyMOOSException(err_msg.c_str());
         }
 
         PyGILState_Release(gstate);
@@ -165,8 +167,9 @@ public:
             bResult = py::bool_(result);
         } catch (const py::error_already_set& e) {
             PyGILState_Release(gstate);
-            throw pyMOOSException(
-                "ActiveQueue:: caught an exception thrown in python callback");
+            std::string err_msg = "ActiveQueue:: caught an exception thrown in python callback:\n";
+            err_msg.append(e.what());
+            throw pyMOOSException(err_msg.c_str());
         }
 
         PyGILState_Release(gstate);


### PR DESCRIPTION
I didn't have as much information as I wanted when debugging code that threw an exception within a pymoos callback, so I modified the wrapper to print out the full `e.what()` message, which provides some of the traceback. I'm finding this useful, so figured I'd submit a PR.

Example output before:
~~~
terminate called after throwing an instance of 'pyMOOSException'
  what():  ActiveQueue:: caught an exception thrown in python callback
~~~

Example output after:
~~~
terminate called after throwing an instance of 'pyMOOSException'
  what():  ActiveQueue:: caught an exception thrown in python callback:
AttributeError: 'Foo' object has no attribute 'bar'

At:
  /path/redacted/moos_file.py(128): moos_callback

Aborted (core dumped)
~~~